### PR TITLE
Fix playback issue after pausing and switching channels

### DIFF
--- a/somafm.py
+++ b/somafm.py
@@ -634,6 +634,7 @@ class SomaFMPlayer:
             self.buffer.start_buffering()
             
             # Start playback
+            self.player.pause = False
             self.player.play(stream_url)
             self.current_channel = channel
             self.is_playing = True


### PR DESCRIPTION
When a channel was paused and the user switched to another channel, the `mpv` player instance would retain its paused state. When switching back to the original channel, the `play` command would not override the paused state, resulting in no audio playback.

This change fixes the issue by explicitly setting `self.player.pause = False` before playing any new stream. This ensures that the player is always in an un-paused state when a channel is selected for playback.