### PR TITLE
feat: Add 14 new color schemes

### DIFF
--- a/somafm.py
+++ b/somafm.py
@@ -379,6 +379,59 @@ class SomaFMPlayer:
     def _get_color_themes(self):
         """Define available color themes"""
         return {
+            # Light Themes (5)
+            'light': {
+                'name': 'Light',
+                'bg_color': curses.COLOR_WHITE,
+                'header': curses.COLOR_BLUE,
+                'selected': curses.COLOR_BLACK,
+                'info': curses.COLOR_RED,
+                'metadata': curses.COLOR_MAGENTA,
+                'instructions': curses.COLOR_CYAN,
+                'favorite': curses.COLOR_RED
+            },
+            'solarized-light': {
+                'name': 'Solarized Light',
+                'bg_color': curses.COLOR_WHITE,
+                'header': curses.COLOR_BLUE,
+                'selected': curses.COLOR_BLACK,
+                'info': curses.COLOR_CYAN,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_MAGENTA,
+                'favorite': curses.COLOR_RED
+            },
+            'gruvbox-light': {
+                'name': 'Gruvbox Light',
+                'bg_color': curses.COLOR_WHITE,
+                'header': curses.COLOR_RED,
+                'selected': curses.COLOR_BLACK,
+                'info': curses.COLOR_GREEN,
+                'metadata': curses.COLOR_BLUE,
+                'instructions': curses.COLOR_YELLOW,
+                'favorite': curses.COLOR_RED
+            },
+            'paper-color': {
+                'name': 'PaperColor',
+                'bg_color': curses.COLOR_WHITE,
+                'header': curses.COLOR_BLUE,
+                'selected': curses.COLOR_BLACK,
+                'info': curses.COLOR_RED,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_MAGENTA,
+                'favorite': curses.COLOR_RED
+            },
+            'classic-light': {
+                'name': 'Classic Light',
+                'bg_color': curses.COLOR_WHITE,
+                'header': curses.COLOR_BLACK,
+                'selected': curses.COLOR_BLUE,
+                'info': curses.COLOR_BLACK,
+                'metadata': curses.COLOR_BLACK,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_RED
+            },
+
+            # Dark Themes (15)
             'default': {
                 'name': 'Default Dark',
                 'bg_color': curses.COLOR_BLACK,
@@ -387,16 +440,6 @@ class SomaFMPlayer:
                 'info': curses.COLOR_YELLOW,
                 'metadata': curses.COLOR_MAGENTA,
                 'instructions': curses.COLOR_BLUE,
-                'favorite': curses.COLOR_RED
-            },
-            'light': {
-                'name': 'Light Theme',
-                'bg_color': curses.COLOR_WHITE,
-                'header': curses.COLOR_BLUE,
-                'selected': curses.COLOR_BLACK,
-                'info': curses.COLOR_RED,
-                'metadata': curses.COLOR_MAGENTA,
-                'instructions': curses.COLOR_CYAN,
                 'favorite': curses.COLOR_RED
             },
             'matrix': {
@@ -438,6 +481,106 @@ class SomaFMPlayer:
                 'metadata': curses.COLOR_WHITE,
                 'instructions': curses.COLOR_WHITE,
                 'favorite': curses.COLOR_WHITE
+            },
+            'darcula': {
+                'name': 'Darcula',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_CYAN,
+                'selected': curses.COLOR_YELLOW,
+                'info': curses.COLOR_BLUE,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_MAGENTA,
+                'favorite': curses.COLOR_RED
+            },
+            'monokai': {
+                'name': 'Monokai',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_MAGENTA,
+                'selected': curses.COLOR_GREEN,
+                'info': curses.COLOR_CYAN,
+                'metadata': curses.COLOR_YELLOW,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_RED
+            },
+            'solarized-dark': {
+                'name': 'Solarized Dark',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_BLUE,
+                'selected': curses.COLOR_YELLOW,
+                'info': curses.COLOR_CYAN,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_MAGENTA,
+                'favorite': curses.COLOR_RED
+            },
+            'nord': {
+                'name': 'Nord',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_CYAN,
+                'selected': curses.COLOR_WHITE,
+                'info': curses.COLOR_BLUE,
+                'metadata': curses.COLOR_CYAN,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_MAGENTA
+            },
+            'gruvbox-dark': {
+                'name': 'Gruvbox Dark',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_YELLOW,
+                'selected': curses.COLOR_WHITE,
+                'info': curses.COLOR_GREEN,
+                'metadata': curses.COLOR_CYAN,
+                'instructions': curses.COLOR_RED,
+                'favorite': curses.COLOR_RED
+            },
+            'dracula': {
+                'name': 'Dracula',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_MAGENTA,
+                'selected': curses.COLOR_CYAN,
+                'info': curses.COLOR_GREEN,
+                'metadata': curses.COLOR_YELLOW,
+                'instructions': curses.COLOR_WHITE,
+                'favorite': curses.COLOR_RED
+            },
+            'tokyo-night': {
+                'name': 'Tokyo Night',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_BLUE,
+                'selected': curses.COLOR_CYAN,
+                'info': curses.COLOR_GREEN,
+                'metadata': curses.COLOR_MAGENTA,
+                'instructions': curses.COLOR_WHITE,
+                'favorite': curses.COLOR_RED
+            },
+            'cyberpunk': {
+                'name': 'Cyberpunk',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_MAGENTA,
+                'selected': curses.COLOR_CYAN,
+                'info': curses.COLOR_YELLOW,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_RED
+            },
+            'vampire': {
+                'name': 'Vampire',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_RED,
+                'selected': curses.COLOR_WHITE,
+                'info': curses.COLOR_MAGENTA,
+                'metadata': curses.COLOR_CYAN,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_YELLOW
+            },
+            'forest': {
+                'name': 'Forest',
+                'bg_color': curses.COLOR_BLACK,
+                'header': curses.COLOR_GREEN,
+                'selected': curses.COLOR_WHITE,
+                'info': curses.COLOR_YELLOW,
+                'metadata': curses.COLOR_GREEN,
+                'instructions': curses.COLOR_BLUE,
+                'favorite': curses.COLOR_RED
             }
         }
 
@@ -481,7 +624,7 @@ class SomaFMPlayer:
             "# Configuration file for SomaFM TUI Player": "",
             "# buffer_minutes: Duration of audio buffering in minutes": "",
             "# buffer_size_mb: Maximum size of buffer in megabytes": "",
-            "# theme: Color theme (default, light, matrix, ocean, sunset, monochrome)": "",
+            "# theme: Color theme (light, solarized-light, gruvbox-light, paper-color, classic-light, default, matrix, ocean, sunset, monochrome, darcula, monokai, solarized-dark, nord, gruvbox-dark, dracula, tokyo-night, cyberpunk, vampire, forest)": "",
             "# alternative_bg_mode: Use pure black background instead of dark gray (true/false)": "",
             "buffer_minutes": 5,
             "buffer_size_mb": 50,


### PR DESCRIPTION
Adds 14 new color schemes to the application, increasing the total number of themes to 20.

The new set of themes consists of 5 light and 15 dark schemes, including popular options like Darcula, Monokai, Solarized, and Gruvbox.

The configuration file help text has been updated to list all available theme names.